### PR TITLE
Preferences (for gcalendar), Category generation endpoint

### DIFF
--- a/cal/api/serializers.py
+++ b/cal/api/serializers.py
@@ -14,7 +14,7 @@ class GCalendarSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = GCalendar
-        fields = ('calendar_id', 'meta', 'summary')
+        fields = ('id', 'calendar_id', 'meta', 'summary', 'enabled_by_default')
 
 
 class GEventSerializer(serializers.ModelSerializer):
@@ -25,7 +25,6 @@ class GEventSerializer(serializers.ModelSerializer):
                 'calendar', 'google_id', 'i_cal_uid', 'color_index', 'description',
                 'status', 'transparency', 'all_day_event', 'timezone',
                 'end_time_unspecified', 'recurring_event_id', 'color')
-        # color = serializers.SerializerMethodField()
 
     class GCalendarField(serializers.Field):
         def to_representation(self, obj):

--- a/cal/api/urls.py
+++ b/cal/api/urls.py
@@ -9,6 +9,8 @@ urlpatterns = patterns(
     url(r'^v1/sync/$', views.sync),
 
     url(r'^v1/gcalendars/$', views.GCalendarList.as_view()),
+    url(r'^v1/gcalendars/(?P<pk>[0-9]+)/toggle-enabled/?$',
+        views.GCalendarToggleEnabled.as_view()),
     url(r'^v1/gevents/$', views.GEventList.as_view()),
     url(r'^v1/colorcategories/$', views.ColorCategoryList.as_view()),
     url(r'^v1/stats/$', views.StatisticList.as_view()),

--- a/cal/api/views.py
+++ b/cal/api/views.py
@@ -52,6 +52,29 @@ class GCalendarList(generics.ListAPIView):
         return GCalendar.objects.filter(user=self.request.user)
 
 
+class GCalendarToggleEnabled(generics.GenericAPIView):
+    """
+    API endpoint primarily used for toggling calendar defaults
+    """
+    serializer_class = GCalendarSerializer
+
+    def get_queryset(self):
+        return GCalendar.objects.filter(user=self.request.user)
+
+    def get(self, request, *args, **kwargs):
+        try:
+            calendar = GCalendar.objects.filter(user=request.user).get(id=kwargs['pk'])
+        except GCalendar.DoesNotExist:
+            raise Exception("Could not find your calendar with primary key {}"
+                    .format(kwargs['pk']))
+
+        isNowEnabled = False if calendar.enabled_by_default else True
+        calendar.enabled_by_default = isNowEnabled
+        calendar.save()
+
+        return Response("Calendar {} is now enabled? {}".format(calendar, isNowEnabled))
+
+
 class GEventList(generics.ListAPIView):
     """
     API endpoint to query for Google Calendar events, without pruning for duplicates

--- a/cal/cal/migrations/0044_gcalendar_enabled_by_default.py
+++ b/cal/cal/migrations/0044_gcalendar_enabled_by_default.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cal', '0043_gcalendar_color_index'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='gcalendar',
+            name='enabled_by_default',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/cal/cal/models.py
+++ b/cal/cal/models.py
@@ -143,6 +143,8 @@ class GCalendar(models.Model):
     summary = models.CharField(max_length=250, help_text="Title of the calendar")
     meta = JSONField(default="{}", blank=True)
 
+    enabled_by_default = models.BooleanField(default=True)
+
     def __str__(self):
         return "{}'s calendar {}".format(self.user, self.calendar_id)
 

--- a/cal/cal/models.py
+++ b/cal/cal/models.py
@@ -100,21 +100,29 @@ class Profile(models.Model):
                                    color_index=color_index,
                                    label=label,
                                    )
-                cc.save()
-                print "Created color category {}".format(cc)
+                # Only create this color category if there are meaningful stats
+                # for it
+                if len(cc.query()) > 0:
+                    cc.save()
+                    print "Created color category {}".format(cc)
 
         # Create categories for event colors
         for key in GEvent.EVENT_COLORS_KEYS:
             # Skip default events, those will use a calendar key
             if key == "1":
                 continue
-            qs = GEvent.objects.filter(calendar__user=self.user, color_index=key)
+            qs = GEvent.objects.filter(calendar__user=self.user,
+                                      color_index=key,
+                                      all_day_event=False
+                                      )
             if qs.count() > 0:
                 create_category_if_nonexistent(color_index=key)
 
         # Create categories for default event colors on separate calendars
         for calendar in GCalendar.objects.filter(user=self.user):
-            qs = GEvent.objects.filter(calendar__user=self.user, color_index="1")
+            qs = GEvent.objects.filter(calendar__user=self.user,
+                                       color_index="1",
+                                       all_day_event=False)
             if qs.count() > 0:
                 create_category_if_nonexistent(color_index="1", gcalendar=calendar)
 

--- a/cal/cal/static/js/app.js
+++ b/cal/cal/static/js/app.js
@@ -169,10 +169,10 @@ analyticsApp.controller('CalendarCtrl', function UiCalendarCtrl($scope, $http, $
             var collectedEvents = [];
             var eventPromises = response.data.results.map(function(gcal) {
 
-              // Initialize cached calendars
+              // Initialize our calendar objects
               if ($scope.calendars[gcal.calendar_id] === undefined) {
                   $scope.calendars[gcal.calendar_id] = gcal;
-                  $scope.calendars[gcal.calendar_id].enabled = true;
+                  $scope.calendars[gcal.calendar_id].enabled = gcal.enabled_by_default;
               }
 
               return $http({
@@ -261,6 +261,15 @@ analyticsApp.controller('CalendarCtrl', function UiCalendarCtrl($scope, $http, $
       if(uiCalendarConfig.calendars[calendarName] !== undefined){
         uiCalendarConfig.calendars[calendarName].fullCalendar('refetchEvents');
       }
+    };
+
+    this.toggleEnabled = function(calendarPrimaryKey) {
+      $http({
+        method: 'GET',
+        url: "/v1/gcalendars/" + calendarPrimaryKey + "/toggle-enabled/"
+      }).then(function toggledSuccess(data) {}, function toggledFail(data) {
+        console.log("Could not save preferences for calendar " + calendarPrimaryKey);
+      });
     };
 
     this.eventSources = [this.events];

--- a/cal/cal/templates/home_logged_in.html
+++ b/cal/cal/templates/home_logged_in.html
@@ -155,11 +155,12 @@
     {% if request.user.is_staff %}
       <div>
         <h4 class="well">Options</h4>
-        <a href="/v1/sync"><button class="btn btn-primary pull-left">Sync</button></a>
-        <a href="/v1/sync?full_sync=true"><button class="btn btn-primary pull-left">Full Sync</button></a>
-        <a href="/v1/sync?sync_all=true"><button class="btn btn-primary pull-left">Sync All Calendars</button></a>
+        <a href="/v1/sync"><button class="btn btn-primary pull-left">Inc. Sync Main Calendar</button></a>
+        <a href="/v1/sync?full_sync=true"><button class="btn btn-primary pull-left">Full Sync Main Calendar</button></a>
+        <a href="/v1/sync?sync_all=true"><button class="btn btn-primary pull-left">Inc. Sync All Calendars</button></a>
         <a href="/v1/sync?full_sync=true&sync_all=true"><button class="btn btn-primary pull-left">Full Sync All Calendars</button></a>
         <a href="/auth/clear"><button class="btn btn-primary pull-left">Reset Credentials</button></a>
+        <a href="/admin/generate-categories"><button class="btn btn-primary pull-left">Generate Categories</button></a>
       </div>
     {% endif %}
   </div>

--- a/cal/cal/templates/home_logged_in.html
+++ b/cal/cal/templates/home_logged_in.html
@@ -59,7 +59,8 @@
       <ul class="dropdown-menu">
         <li ng-repeat="cal in calendars">
           <a href="#">
-            <input type="checkbox" ng-model="cal.enabled" ng-click="$ctrl.refresh('panalytics')">
+            <input type="checkbox" ng-model="cal.enabled"
+                   ng-click="$ctrl.toggleEnabled(cal.id); $ctrl.refresh('panalytics');">
             {% verbatim %} {{ cal.summary }} {% endverbatim %}
           </a>
         </li>

--- a/cal/cal/templates/home_logged_in.html
+++ b/cal/cal/templates/home_logged_in.html
@@ -161,7 +161,7 @@
         <a href="/v1/sync?sync_all=true"><button class="btn btn-primary pull-left">Inc. Sync All Calendars</button></a>
         <a href="/v1/sync?full_sync=true&sync_all=true"><button class="btn btn-primary pull-left">Full Sync All Calendars</button></a>
         <a href="/auth/clear"><button class="btn btn-primary pull-left">Reset Credentials</button></a>
-        <a href="/admin/generate-categories"><button class="btn btn-primary pull-left">Generate Categories</button></a>
+        <a href="/admin/generate-categories"><button class="btn btn-primary pull-left" style="margin-bottom: 25px;">Generate Categories</button></a>
       </div>
     {% endif %}
   </div>

--- a/cal/cal/urls.py
+++ b/cal/cal/urls.py
@@ -7,6 +7,8 @@ urlpatterns = patterns(
     url(r'^$', 'cal.views.home', name='home'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^admin/', include('loginas.urls')),
+    url(r'^admin/generate-categories', 'cal.views.generate_categories',
+        name='generate_categories'),
     url(r'^logout$', 'cal.views.logout_view', name='logout_view'),
     url(r'^auth/google', 'cal.views.google_auth', name='google_auth'),
     url(r'^auth/clear', 'cal.views.clear_auth', name='clear_auth'),

--- a/cal/cal/views.py
+++ b/cal/cal/views.py
@@ -36,6 +36,11 @@ def clear_auth(request):
     return HttpResponseRedirect("/")
 
 @login_required
+def generate_categories(request):
+    request.user.profile.generate_categories()
+    return HttpResponseRedirect("/")
+
+@login_required
 def accounts_profile(request):
     """
     Shows the account information for a user


### PR DESCRIPTION
Fixes #35 
- Adds admin endpoint for generating categories
- Only generates meaningful categories (skips those that will display as 0 hours)
- Save enable/disable preference in backend upon frontend toggle
