### PR TITLE
pie chart colors now match calendar/event colors

### DIFF
--- a/cal/api/serializers.py
+++ b/cal/api/serializers.py
@@ -52,6 +52,7 @@ class StatisticSerializer(serializers.ModelSerializer):
 class ColorCategorySerializer(serializers.ModelSerializer):
 
     hours = serializers.SerializerMethodField()
+    category_color = serializers.SerializerMethodField()
 
     def get_fields(self, *args, **kwargs):
         fields = super(ColorCategorySerializer, self).get_fields(*args, **kwargs)
@@ -60,13 +61,16 @@ class ColorCategorySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ColorCategory
-        fields = ('id', 'color_index', 'label', 'hours', 'calendar')
+        fields = ('id', 'label', 'hours', 'calendar', 'category_color')
 
     def get_hours(self, obj):
         calendar_ids = self.context['calendar_ids']
         start = self.context['start']
         end = self.context['end']
         return obj.hours(calendar_ids=calendar_ids, start=start, end=end)
+
+    def get_category_color(self, obj):
+        return obj.category_color()
 
 
 class TagSerializer(serializers.ModelSerializer):

--- a/cal/cal/helpers.py
+++ b/cal/cal/helpers.py
@@ -1,3 +1,4 @@
+from cal.constants import GOOGLE_CALENDAR_COLORS
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
 from django.utils import timezone
@@ -61,6 +62,17 @@ def truncated_queryset(queryset, edge, start, end):
     return queryset
 
 
+def get_color(calendar, color_index):
+    """
+    Takes in a calendar and a color_index and returns the associated color codes
+    from constants.py.
+    """
+    if color_index == "1":
+        return GOOGLE_CALENDAR_COLORS['calendar'].get(calendar.color_index)
+    else:
+        return GOOGLE_CALENDAR_COLORS['event'].get(color_index)
+
+
 class EventCollection:
     """
     Represents a Set of events
@@ -79,7 +91,7 @@ class EventCollection:
         Returns a set of events.
         """
         return self._events_func()
-    
+
     def intersection(self, other):
 
         def lazy_get_events():
@@ -107,7 +119,7 @@ class EventCollection:
             total += e.end - e.start
 
         return int(total.total_seconds())
-        
+
 
 class TimeNodeChain(EventCollection):
 
@@ -165,7 +177,7 @@ class TimeNodeChain(EventCollection):
                 current = current.next
 
             self._total_time = total.total_seconds()
-        
+
         return self._total_time
 
     def insert(self, timenode, return_overwrites=False):
@@ -249,7 +261,7 @@ class TimeNodeChain(EventCollection):
             current = current.next
 
         return chain
-    
+
     def __str__(self):
         if not self.head:
             return "<Empty TimeNodeChain>"
@@ -343,7 +355,7 @@ class TimeNode:
             inserted, next_node = try_insert(next_node)
 
         return timenode
-                    
+
     def old_insert(self, timenode):
         """
         Inserts a single TimeNode in O(n) time and returns the current node.
@@ -406,5 +418,5 @@ class TimeNode:
                 self.next.insert(timenode)
             elif self.prev:
                 self.prev.insert(timenode)
-            
+
             return timenode

--- a/cal/cal/models.py
+++ b/cal/cal/models.py
@@ -1,6 +1,6 @@
 from apiclient.discovery import build
 from cal.constants import GOOGLE_CALENDAR_COLORS
-from cal.helpers import EventCollection, TimeNode, TimeNodeChain, ensure_timezone_awareness
+from cal.helpers import EventCollection, TimeNode, TimeNodeChain, ensure_timezone_awareness, get_color
 from datetime import datetime, timedelta
 from django.contrib.auth.models import User
 from django.db import models
@@ -421,11 +421,7 @@ class GEvent(Event):
 
     @property
     def color(self):
-        # For events with default color, use the calendar color instead
-        if self.color_index == "1":
-            color = GOOGLE_CALENDAR_COLORS['calendar'].get(self.calendar.color_index)
-        else:
-            color = GOOGLE_CALENDAR_COLORS['event'].get(self.color_index)
+        color = get_color(self.calendar, self.color_index)
 
         if color:
             return color
@@ -557,6 +553,9 @@ class ColorCategory(models.Model, EventCollection):
 
         return EventCollection(lambda: events).total_time() / 3600
 
+    def category_color(self):
+        return get_color(self.calendar, self.color_index)['background']
+
     def get_events(self, calendar_ids=None, start=None, end=None):
         qs = self.query(calendar_ids, start, end)
         return set(qs)
@@ -585,7 +584,8 @@ class ColorCategory(models.Model, EventCollection):
             events_qs = events_qs.filter(start__lt=end)
         else:
             events_qs = events_qs.filter(start__lt=datetime.now(pytz.utc))
-
+        # print events_qs[0].color
+        # print len(events_qs)
         return events_qs
 
     def get_hours_per_week(self, calendar_ids=None, start=None, end=None):

--- a/cal/cal/models.py
+++ b/cal/cal/models.py
@@ -584,8 +584,6 @@ class ColorCategory(models.Model, EventCollection):
             events_qs = events_qs.filter(start__lt=end)
         else:
             events_qs = events_qs.filter(start__lt=datetime.now(pytz.utc))
-        # print events_qs[0].color
-        # print len(events_qs)
         return events_qs
 
     def get_hours_per_week(self, calendar_ids=None, start=None, end=None):

--- a/cal/cal/static/js/app.js
+++ b/cal/cal/static/js/app.js
@@ -199,7 +199,8 @@ analyticsApp.controller('CategoriesCtrl', function($scope, $http){
           id: category.id,
           label: category.label,
           hours: category.hours,
-          include: true
+          include: true,
+          color: category.category_color,
         });
       }
       $scope.categories.dataLoaded = true;

--- a/cal/cal/static/js/app.js
+++ b/cal/cal/static/js/app.js
@@ -200,7 +200,7 @@ analyticsApp.controller('CategoriesCtrl', function($scope, $http){
           label: category.label,
           hours: category.hours,
           include: true,
-          color: category.category_color,
+          color: category.category_color
         });
       }
       $scope.categories.dataLoaded = true;


### PR DESCRIPTION
Decided to remove color_index from the ColorCategory serializer and add a category_color since this field (versus just knowing the color index) seems more pertinent to whatever code is working with color categories. Evaluating the color codes associated with a color_index is repeat code, so I decided to move it helpers.py.